### PR TITLE
Fix some calls to NetworkX where draw_networkx_edges, draw_networkx_nodes had changed upstream.

### DIFF
--- a/regraph/attribute_sets.py
+++ b/regraph/attribute_sets.py
@@ -29,7 +29,7 @@ import numpy as np
 import math
 import sys
 
-from greenery.lego import parse
+from greenery import parse
 
 from regraph.exceptions import AttributeSetError
 
@@ -538,7 +538,7 @@ class RegexSet(AttributeSet):
 
         * If `other` is a string, a Python dict or a FiniteSet,
           it is converted to a regex pattern, after which it
-          is parsed by `greenery.lego.parse` method and its
+          is parsed by `greenery.parse` method and its
           intersection with the pattern of the `self` is found.
           The library `greenery` finds the intersection between two
           regex's by constructing corresponding FSM's (finite state
@@ -620,7 +620,7 @@ class RegexSet(AttributeSet):
 
         * If `other` is a string, a Python dict or a FiniteSet,
           it is converted to a regex pattern, after which it
-          is parsed by `greenery.lego.parse` method and its
+          is parsed by `greenery.parse` method and its
           difference with the pattern of the `self` is found.
           See more details here:
           https://github.com/qntm/greenery

--- a/regraph/backends/networkx/plotting.py
+++ b/regraph/backends/networkx/plotting.py
@@ -96,7 +96,7 @@ def plot_graph(graph, filename=None, parent_pos=None, title=None):
         graph._graph, k=k, pos=pos, fixed=fixed, iterations=iterations)
     nx.draw_networkx_nodes(
         graph._graph, pos, node_color=[[0.6, 0.8, 0.047]] * len(graph.nodes()),
-        node_size=200, scale=1.0)
+        node_size=200)
     nx.draw_networkx_edges(graph._graph, pos, alpha=0.4, width=2.0, node_size=200)
 
     labels = {}
@@ -195,7 +195,7 @@ def plot_instance(graph, pattern, instance, filename=None,
     nx.draw_networkx_nodes(
         graph._graph, pos, node_color=new_colors, node_size=200)
     nx.draw_networkx_edges(
-        graph._graph, pos, alpha=0.4, width=2.0, node_size=200, scale=1.0)
+        graph._graph, pos, alpha=0.4, width=2.0, node_size=200)
 
     # Draw pattern edges highlighted
     edgelist = [(instance[edge[0]], instance[edge[1]])
@@ -373,7 +373,7 @@ def plot_rule(rule, filename=None, title=None):
     _set_limits(all_pos, all_label_pos)
     nx.draw_networkx_nodes(rule.lhs._graph, lhs_pos,
                            node_color=lhs_colors,
-                           node_size=100, arrows=True)
+                           node_size=100)
     nx.draw_networkx_edges(rule.lhs._graph, lhs_pos, alpha=0.4, node_size=100)
     nx.draw_networkx_labels(rule.lhs._graph, lhs_label_pos, lhs_labels, font_size=11)
 
@@ -383,7 +383,7 @@ def plot_rule(rule, filename=None, title=None):
     _set_limits(all_pos, all_label_pos)
     nx.draw_networkx_nodes(rule.p._graph, p_pos,
                            node_color=p_colors,
-                           node_size=100, arrows=True)
+                           node_size=100)
     nx.draw_networkx_edges(rule.p._graph, p_pos, alpha=0.4, node_size=100)
     nx.draw_networkx_labels(rule.p._graph, p_label_pos, p_labels, font_size=11)
 
@@ -393,7 +393,7 @@ def plot_rule(rule, filename=None, title=None):
     _set_limits(all_pos, all_label_pos)
     nx.draw_networkx_nodes(rule.rhs._graph, rhs_pos,
                            node_color=rhs_colors,
-                           node_size=100, arrows=True)
+                           node_size=100)
     nx.draw_networkx_edges(rule.rhs._graph, rhs_pos, alpha=0.4, node_size=100)
     nx.draw_networkx_labels(rule.rhs._graph, rhs_label_pos, rhs_labels, font_size=11)
 


### PR DESCRIPTION
These no longer had scale/arrows parameters and the upstream greenery dependency had the greenery.lego module removed entirely, and the parse function now lives directly in the greenery module.

I ran the tests, and they seem fine, and I've been using this myself for some graph rewrite stuff (very nice library by the way!)

And if there's any other changes you want me to make, now is the time :)